### PR TITLE
feat(I18n): Support es and en languages in landing page 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+.vscode/

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,6 +42,17 @@ module.exports = {
                 tailwindConfig: `tailwind.config.js`,
             },
         },
+        // I18n
+        {
+            resolve: `gatsby-plugin-intl`,
+            options: {
+                path: `${__dirname}/src/intl`,
+                languages: [`en`, `es`],
+                defaultLanguage: `en`,
+                // option to redirect to `/ko` when connecting `/`
+                redirect: true,
+            },
+        },
         `gatsby-transformer-remark`,
 
         // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,6 +1061,51 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@formatjs/intl-displaynames": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.2.tgz",
+      "integrity": "sha512-qwYxEWJEIplshOMWyLGl2g0d9g/25oQm8GWWCRcagHhv4YIfSJM5+GCTYNJiQImm10pKfEhoV5ezDs0Pr/8CRA==",
+      "requires": {
+        "@formatjs/intl-utils": "^2.2.0"
+      }
+    },
+    "@formatjs/intl-listformat": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-1.4.2.tgz",
+      "integrity": "sha512-e4ooLDRkNpwlswXLTuSB34catJSWqnYVITBQl+rOLLAdIqVxowqX5ngWCAhaXGIMs58ohaZMor5ikJpUbPhgTA==",
+      "requires": {
+        "@formatjs/intl-utils": "^2.2.0"
+      }
+    },
+    "@formatjs/intl-pluralrules": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.3.tgz",
+      "integrity": "sha512-piBxSgQLRcaM754lwEjnNWqtMZfqPTjLGp9qqE1pktNUge46Ub10WToos9qYssKuuxy4RzKUeklvSsxwhcT1ZQ==",
+      "requires": {
+        "@formatjs/intl-utils": "^2.2.0"
+      }
+    },
+    "@formatjs/intl-relativetimeformat": {
+      "version": "4.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.10.tgz",
+      "integrity": "sha512-lQXqwywTcWL88VV+6RC1xShZjH0ry4/TEQHKGcTF3ObJp2P61EHIu8UftYgFfDqRDSV9/yQBiyStaBZWbHNlzg==",
+      "requires": {
+        "@formatjs/intl-utils": "^2.2.0"
+      }
+    },
+    "@formatjs/intl-unified-numberformat": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.0.tgz",
+      "integrity": "sha512-wLT3myYq6fUhJYUh53tt5fMok+sUqO3Jy1XeSqYTphP7MmQl38tHqAIL65Dxh7M6/QlDEQTOkMZNpQcnT0AzaQ==",
+      "requires": {
+        "@formatjs/intl-utils": "^2.2.0"
+      }
+    },
+    "@formatjs/intl-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.2.0.tgz",
+      "integrity": "sha512-+Az7tR1av1DHZu9668D8uh9atT6vp+FFmEF8BrEssv0OqzpVjpVBGVmcgPzQP8k2PQjVlm/h2w8cTt0knn132w=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1617,6 +1662,20 @@
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
       "integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
+    "@types/invariant": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.31.tgz",
+      "integrity": "sha512-jMlgg9pIURvy9jgBHCjQp/CyBjYHUwj91etVcDdXkFl2CwTFiQlB+8tcsMeXpXf2PFE5X2pjk4Gm43hQSMHAdA=="
     },
     "@types/json-schema": {
       "version": "7.0.4",
@@ -3231,6 +3290,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-lang": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/browser-lang/-/browser-lang-0.1.0.tgz",
+      "integrity": "sha512-p4mdcU9fIsoDtbAVorKtxo5H86mK040MYn96yshyhfN3OF0iySuITgR8IxldI72MJAultMnwqDgwfWWwjUrSsw=="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -8216,6 +8280,19 @@
         "@emotion/babel-preset-css-prop": "^10.0.27"
       }
     },
+    "gatsby-plugin-intl": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-intl/-/gatsby-plugin-intl-0.3.3.tgz",
+      "integrity": "sha512-VPugNJv3GDkT6RcOBfncZPw3Eqh98RyvChsXfX7VuMQ8mBVoNB6XyNSIiEGG/atxFrpSp/r3WUKpnzpLLpY5dg==",
+      "requires": {
+        "@babel/runtime": "^7.8.4",
+        "@formatjs/intl-pluralrules": "^1.5.2",
+        "@formatjs/intl-relativetimeformat": "^4.5.9",
+        "browser-lang": "^0.1.0",
+        "intl": "^1.2.5",
+        "react-intl": "^3.12.0"
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.48.tgz",
@@ -9868,6 +9945,33 @@
         "es-abstract": "^1.17.0-next.1",
         "has": "^1.0.3",
         "side-channel": "^1.0.2"
+      }
+    },
+    "intl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
+      "integrity": "sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94="
+    },
+    "intl-format-cache": {
+      "version": "4.2.22",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.22.tgz",
+      "integrity": "sha512-LFa7/3bUN5v6/QqOkcjSryPwffjnX+YiLgYQa9QJqNiHJfFgAnr0ssM/davI1FhgoW398SR36HHhm1X2Poq6NQ=="
+    },
+    "intl-messageformat": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.8.4.tgz",
+      "integrity": "sha512-yS0cLESCKCYjseCOGXuV4pxJm/buTfyCJ1nzQjryHmSehlptbZbn9fnlk1I9peLopZGGbjj46yHHiTAEZ1qOTA==",
+      "requires": {
+        "intl-format-cache": "^4.2.21",
+        "intl-messageformat-parser": "^3.6.4"
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.6.4.tgz",
+      "integrity": "sha512-RgPGwue0mJtoX2Ax8EmMzJzttxjnva7gx0Q7mKJ4oALrTZvtmCeAw5Msz2PcjW4dtCh/h7vN/8GJCxZO1uv+OA==",
+      "requires": {
+        "@formatjs/intl-unified-numberformat": "^3.2.0"
       }
     },
     "into-stream": {
@@ -14146,6 +14250,25 @@
         }
       }
     },
+    "react-intl": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-3.12.1.tgz",
+      "integrity": "sha512-cgumW29mwROIqyp8NXStYsoIm27+8FqnxykiLSawWjOxGIBeLuN/+p2srei5SRIumcJefOkOIHP+NDck05RgHg==",
+      "requires": {
+        "@formatjs/intl-displaynames": "^1.2.0",
+        "@formatjs/intl-listformat": "^1.4.1",
+        "@formatjs/intl-relativetimeformat": "^4.5.9",
+        "@formatjs/intl-unified-numberformat": "^3.2.0",
+        "@formatjs/intl-utils": "^2.2.0",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/invariant": "^2.2.31",
+        "hoist-non-react-statics": "^3.3.2",
+        "intl-format-cache": "^4.2.21",
+        "intl-messageformat": "^7.8.4",
+        "intl-messageformat-parser": "^3.6.4",
+        "shallow-equal": "^1.2.1"
+      }
+    },
     "react-is": {
       "version": "16.8.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
@@ -15145,6 +15268,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/shallow-compare/-/shallow-compare-1.2.2.tgz",
       "integrity": "sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg=="
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-plugin-styled-components": "^1.10.7",
     "gatsby": "^2.19.45",
     "gatsby-image": "^2.2.44",
+    "gatsby-plugin-intl": "^0.3.3",
     "gatsby-plugin-manifest": "^2.2.48",
     "gatsby-plugin-offline": "^3.0.41",
     "gatsby-plugin-react-helmet": "^3.1.24",

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,7 +1,8 @@
 import React from "react"
 import AnchorLink from "react-anchor-link-smooth-scroll"
+import { FormattedMessage, Link } from "gatsby-plugin-intl"
+
 import { Button, Logo } from "../commons"
-import { Link } from "gatsby"
 
 const Header = () => (
     <header className="sticky top-0 bg-white shadow">
@@ -10,26 +11,26 @@ const Header = () => (
                 <div className="w-12 mr-3">
                     <Logo />
                 </div>
-                Fight COVID-19
-
+                <FormattedMessage id={"NAME_APP"} />
             </div>
             <div className="flex mt-4 sm:mt-0">
                 <AnchorLink className="px-4" href="#features">
-                    Principles
+                    <FormattedMessage id={"PRINCIPLES"} />
                 </AnchorLink>
                 <Link className="px-4" to="/blog">
-                    Blog
+                    <FormattedMessage id={"BLOG"} />
                 </Link>
                 <AnchorLink className="px-4" href="#collaborate">
-                    Collaborate
+                    <FormattedMessage id={"COLLABORATE"} />
                 </AnchorLink>
                 <AnchorLink className="px-4" href="#testimonials">
-                    Testimonials
+                    <FormattedMessage id={"TESTIMONIALS"} />
                 </AnchorLink>
-                
             </div>
             <div className="hidden md:block">
-                <Button className="text-sm">Use app</Button>
+                <Button className="text-sm">
+                    <FormattedMessage id={"USE_APP"} />
+                </Button>
             </div>
         </div>
     </header>

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1,0 +1,25 @@
+{
+    "NAME_APP": "Fight COVID-19",
+    "USE_APP": "Use app",
+    "PRINCIPLES": "Principles",
+    "TESTIMONIALS": "Testimonials",
+    "BLOG": "Blog",
+    "COLLABORATE": "Collaborate",
+
+    "MAIN_MESSAGE": "Let's win the fight against COVID-19",
+    "MAIN_MESSAGE_DESCRIPTION": "We will use the amazing skills of all the team to create a world high impact surveillance app, supporting the necessities of the world facing the COVID pandemic.",
+    "MAIN_MESSAGE_NOTE": "Also available web version, android and iOS",
+    "PRINCIPLE_1_TITLE": "Detect alarm signs",
+    "PRINCIPLE_1_DESCRIPTION": "An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio velna vitae auctor integer.",
+    "PRINCIPLE_2_TITLE": "Suggesting",
+    "PRINCIPLE_2_DESCRIPTION": "To relief the load of the healthcare system by redirecting the low risk patients to sites with reliable information about health care and redirect the high-risk patients to the closest medical facility.",
+    "PRINCIPLE_3_TITLE": "Reporting",
+    "PRINCIPLE_3_DESCRIPTION": "To serve as generators of real-time information.",
+    "PRINCIPLE_4_TITLE": "Linking",
+    "PRINCIPLE_4_DESCRIPTION": "To keep close links with healthcare authorities and generate useful epidemiological information.",
+    "ABOUT_US": "About us",
+    "ABOUT_US_DESCRIPTION": "Fight COVID-19 is a non-profit, collaborative community democratizing AI to assist in the detection and triage of COVID-19 cases",
+    "HOW_CONTRIBUTE": "How to contribute",
+    "READ_MORE": "Read more in ",
+    "READY": "Ready ?"
+}

--- a/src/intl/es.json
+++ b/src/intl/es.json
@@ -1,0 +1,25 @@
+{
+    "NAME_APP": "Fight COVID-19",
+    "USE_APP": "Usar aplicación",
+    "PRINCIPLES": "Principios",
+    "TESTIMONIALS": "Testimonios",
+    "BLOG": "Blog",
+    "COLLABORATE": "Colaborar",
+    
+    "MAIN_MESSAGE": "Ganemos la lucha contra COVID-19",
+    "MAIN_MESSAGE_DESCRIPTION": "Utilizaremos las increíbles habilidades de todo el equipo para crear una aplicación de vigilancia mundial de alto impacto, que cubra las necesidades del mundo que enfrenta la pandemia de COVID",
+    "MAIN_MESSAGE_NOTE": "También disponible versión web, Android e iOS",
+    "PRINCIPLE_1_TITLE": "Detectar signos de alarma",
+    "PRINCIPLE_1_DESCRIPTION": "Un enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio velna vitae auctor integer",
+    "PRINCIPLE_2_TITLE": "Sugerir",
+    "PRINCIPLE_2_DESCRIPTION": "Para aliviar la carga del sistema de atención médica al redirigir a los pacientes de bajo riesgo a sitios con información confiable sobre la atención médica y redirigir a los pacientes de alto riesgo al centro médico más cercano",
+    "PRINCIPLE_3_TITLE": "Informes",
+    "PRINCIPLE_3_DESCRIPTION": "Para servir como generadores de información en tiempo real",
+    "PRINCIPLE_4_TITLE": "Vinculación",
+    "PRINCIPLE_4_DESCRIPTION": "Para mantener vínculos estrechos con las autoridades sanitarias y generar información epidemiológica útil",
+    "ABOUT_US": "Acerca de nosotros",
+    "ABOUT_US_DESCRIPTION": "Fight COVID-19 es una comunidad sin fines de lucro y colaborativa que democratiza la IA para ayudar en la detección y clasificación de casos de COVID-19",
+    "HOW_CONTRIBUTE": "Cómo contribuir",
+    "READ_MORE": "Leer más en",
+    "READY": "listo ?"
+}

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -1,5 +1,7 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
+import { FormattedMessage } from "gatsby-plugin-intl"
+
 
 import Layout from "../components/layout/Layout"
 import SEO from "../components/seo"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { FormattedMessage } from "gatsby-plugin-intl"
 import {
     Button,
     Card,
@@ -21,18 +22,18 @@ export default () => (
             <div className="container mx-auto px-8 lg:flex">
                 <div className="text-center lg:text-left lg:w-1/2">
                     <h1 className="text-4xl lg:text-5xl xl:text-6xl font-bold leading-none">
-                        Let's win the fight against COVID-19
+                        <FormattedMessage id="MAIN_MESSAGE" />
                     </h1>
                     <p className="text-xl lg:text-2xl mt-6 font-light">
-                        We will use the amazing skills of all the team to create
-                        a world high impact surveillance app, supporting the
-                        necessities of the world facing the COVID pandemic.
+                        <FormattedMessage id="MAIN_MESSAGE_DESCRIPTION" />
                     </p>
                     <p className="mt-8 md:mt-12">
-                        <Button size="lg">Use app</Button>
+                        <Button size="lg">
+                            <FormattedMessage id="USE_APP" />
+                        </Button>
                     </p>
                     <p className="mt-4 text-gray-600">
-                        Also available web version, android and iOS
+                        <FormattedMessage id="MAIN_MESSAGE_NOTE" />
                     </p>
                 </div>
                 <div className="lg:w-1/2">
@@ -43,30 +44,26 @@ export default () => (
         <section id="features" className="py-20 lg:pb-40 lg:pt-48">
             <div className="container mx-auto text-center">
                 <h2 className="text-3xl lg:text-5xl font-semibold">
-                    Principles
+                    <FormattedMessage id="PRINCIPLES" />
                 </h2>
                 <div className="flex flex-col sm:flex-row sm:-mx-3 mt-12">
                     <div className="flex-1 px-3">
                         <Card className="mb-8">
                             <p className="font-semibold text-xl">
-                                Detect alarm signs
+                                <FormattedMessage id="PRINCIPLE_1_TITLE" />
                             </p>
                             <p className="mt-4">
-                                An enim nullam tempor gravida donec enim ipsum
-                                blandit porta justo integer odio velna vitae
-                                auctor integer.
+                                <FormattedMessage id="PRINCIPLE_1_DESCRIPTION" />
                             </p>
                         </Card>
                     </div>
                     <div className="flex-1 px-3">
                         <Card className="mb-8">
-                            <p className="font-semibold text-xl">Suggesting</p>
+                            <p className="font-semibold text-xl">
+                                <FormattedMessage id="PRINCIPLE_2_TITLE" />
+                            </p>
                             <p className="mt-4">
-                                To relief the load of the healthcare system by
-                                redirecting the low risk patients to sites with
-                                reliable information about health care and
-                                redirect the high-risk patients to the closest
-                                medical facility.
+                                <FormattedMessage id="PRINCIPLE_2_DESCRIPTION" />
                             </p>
                         </Card>
                     </div>
@@ -74,18 +71,21 @@ export default () => (
                 <div className="flex flex-col sm:flex-row sm:-mx-3">
                     <div className="flex-1 px-3">
                         <Card className="mb-8">
-                            <p className="font-semibold text-xl">Reporting</p>
+                            <p className="font-semibold text-xl">
+                                <FormattedMessage id="PRINCIPLE_3_TITLE" />
+                            </p>
                             <p className="mt-4">
-                                To serve as generators of real-time information.
+                                <FormattedMessage id="PRINCIPLE_3_DESCRIPTION" />
                             </p>
                         </Card>
                     </div>
                     <div className="flex-1 px-3">
                         <Card className="mb-8">
-                            <p className="font-semibold text-xl">Linking</p>
+                            <p className="font-semibold text-xl">
+                                <FormattedMessage id="PRINCIPLE_4_TITLE" />
+                            </p>
                             <p className="mt-4">
-                                To keep close links with healthcare authorities
-                                and generate useful epidemiological information.
+                                <FormattedMessage id="PRINCIPLE_4_DESCRIPTION" />
                             </p>
                         </Card>
                     </div>
@@ -97,12 +97,10 @@ export default () => (
             primarySlot={
                 <div className="lg:pr-32 xl:pr-48">
                     <h3 className="text-3xl font-semibold leading-tight">
-                        About us
+                        <FormattedMessage id="ABOUT_US" />
                     </h3>
                     <p className="mt-8 text-xl font-light leading-relaxed">
-                        Fight COVID-19 is a non-profit, collaborative community
-                        democratizing AI to assist in the detection and triage
-                        of COVID-19 cases
+                        <FormattedMessage id="ABOUT_US_DESCRIPTION" />
                     </p>
                 </div>
             }
@@ -114,10 +112,10 @@ export default () => (
             primarySlot={
                 <div className="lg:pl-32 xl:pl-48">
                     <h3 className="text-3xl font-semibold leading-tight">
-                        How to contribute
+                        <FormattedMessage id="HOW_CONTRIBUTE" />
                     </h3>
                     <p className="mt-8 text-xl font-light leading-relaxed">
-                        Read more in{" "}
+                        <FormattedMessage id="READ_MORE" />
                         <a href="https://github.com/elcronos/COVID-19#this-is-how-you-can-help">
                             https://github.com/elcronos/COVID-19#this-is-how-you-can-help
                         </a>
@@ -154,7 +152,7 @@ export default () => (
         <section id="testimonials" className="py-20 lg:py-40">
             <div className="container mx-auto">
                 <LabelText className="mb-8 text-gray-600 text-center">
-                    Testimonials
+                    <FormattedMessage id="TESTIMONIALS" />
                 </LabelText>
                 <div className="flex flex-col md:flex-row md:-mx-3">
                     {testimonialsData.map(customer => (
@@ -169,7 +167,9 @@ export default () => (
             </div>
         </section>
         <section className="container mx-auto my-20 py-24 bg-gray-200 rounded-lg text-center">
-            <h3 className="text-5xl font-semibold">Ready ?</h3>
+            <h3 className="text-5xl font-semibold">
+                <FormattedMessage id="READY" />
+            </h3>
             <p className="mt-8 text-xl font-light">
                 Quis lectus nulla at volutpat diam ut. Enim lobortis scelerisque
                 fermentum dui faucibus in.


### PR DESCRIPTION
* Include all `en` strings that currently have
* Translate without supervision `es` strings with google translator

** NOTE: ** sometimes you will need run `gatsby clean` to see the changes in intl files